### PR TITLE
injections: add "relay" to GraphQL highlighting

### DIFF
--- a/queries/ocaml/injections.scm
+++ b/queries/ocaml/injections.scm
@@ -24,6 +24,6 @@
      (quoted_string
       (quoted_string_content) @injection.content))))
 
- (#eq? @_attribute_id "graphql")
+ (#contains? @_attribute_id "graphql" "relay")
  (#set! injection.language "graphql")
  (#set! injection.include-children true))


### PR DESCRIPTION
I didn't test this, but seems like `contains?` can be used here like it is above?