### PR TITLE
fix: Readme missing dependency for conform

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ If you're not using OCaml (you should be) then this plugin is worthless to you.
 
 ```lua
 return {
-    { "tjdevries/ocaml.nvim", build = "make" }
+    {
+        "tjdevries/ocaml.nvim",
+        dependencies = {
+            "stevearc/conform.nvim",
+        },
+        build = "make"
+    },
 }
 ```
 


### PR DESCRIPTION
On first installation I was getting an error (example below) due to a missing conform package, just a simple readme change so if people come across it themselves, saves a future issue being created.

```
E5113: Error while calling lua chunk: ...anmorgan/.local/share/nvim/lazy/ocaml.nvim/lua/ocaml.lua:93: module 'conform' not found:
	no field package.preload['conform']
cache_loader: module conform not found
cache_loader_lib: module conform not found
```