### PR TITLE
Change dune-workspace repository source to url

### DIFF
--- a/binaries/dune-workspace
+++ b/binaries/dune-workspace
@@ -5,4 +5,4 @@
 
 (repository
  (name andrey)
- (source "git+https://github.com/andreypopp/opam-repository-1.git#7617b0899497eaa0447bbc19b15467c7237aa290"))
+ (url "git+https://github.com/andreypopp/opam-repository-1.git#7617b0899497eaa0447bbc19b15467c7237aa290"))


### PR DESCRIPTION
Makefile was failing to run, the repository stanza uses url now.